### PR TITLE
Add room cycling for all available room images + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Room Glow Up
+
+## Cursor Cloud specific instructions
+
+This is a zero-dependency, static HTML/CSS/JS website. There are no build tools, package managers, frameworks, or backend services.
+
+### Running the development server
+
+Serve the repository root with any static HTTP server. The simplest option:
+
+```
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080/index.html` in a browser.
+
+### Key files
+
+- `index.html` — main application (inline CSS + vanilla JS)
+- `decor-test.html` — standalone test page for the Decor Closet image cycling feature
+- `Assets/` — all image assets (PNG furniture/decor items, JPG room backgrounds and UI elements)
+
+### Notes
+
+- There is no linter, test runner, or build step configured in this project.
+- The Google Fonts CDN (`Limelight` font) is loaded at runtime; the page still renders without internet but falls back to `serif`.
+- Opening `index.html` via `file://` may cause CORS issues with image loading in some browsers; always use an HTTP server.

--- a/index.html
+++ b/index.html
@@ -151,6 +151,94 @@ width:140px;
 cursor:grab;
 }
 
+/* GALLERY OVERLAY */
+
+#gallery-overlay{
+display:none;
+position:fixed;
+inset:0;
+z-index:1000;
+background:rgba(0,0,0,.85);
+justify-content:center;
+align-items:center;
+flex-direction:column;
+}
+
+#gallery-overlay.open{
+display:flex;
+}
+
+#gallery-frame{
+position:relative;
+max-width:85vw;
+max-height:80vh;
+cursor:pointer;
+}
+
+#gallery-frame img{
+max-width:85vw;
+max-height:80vh;
+border-radius:10px;
+box-shadow:0 0 40px rgba(255,255,255,.15);
+object-fit:contain;
+}
+
+#gallery-close{
+position:absolute;
+top:-18px;
+right:-18px;
+width:40px;
+height:40px;
+border-radius:50%;
+border:2px solid #fff;
+background:rgba(0,0,0,.7);
+color:#fff;
+font-size:22px;
+cursor:pointer;
+display:flex;
+align-items:center;
+justify-content:center;
+z-index:1001;
+}
+
+#gallery-close:hover{
+background:#fff;
+color:#000;
+}
+
+#gallery-nav{
+display:flex;
+gap:20px;
+margin-top:18px;
+align-items:center;
+}
+
+.gallery-arrow{
+background:none;
+border:2px solid rgba(255,255,255,.5);
+border-radius:50%;
+width:48px;
+height:48px;
+color:#fff;
+font-size:26px;
+cursor:pointer;
+display:flex;
+align-items:center;
+justify-content:center;
+transition:.2s;
+}
+
+.gallery-arrow:hover{
+border-color:#fff;
+background:rgba(255,255,255,.15);
+}
+
+#gallery-counter{
+font-size:16px;
+letter-spacing:2px;
+opacity:.8;
+}
+
 </style>
 </head>
 
@@ -192,6 +280,19 @@ cursor:grab;
 </div>
 
 </section>
+
+<!-- GALLERY OVERLAY -->
+<div id="gallery-overlay">
+<div id="gallery-frame">
+<button id="gallery-close">&times;</button>
+<img id="gallery-img" src="Assets/gallerydoors.jpg" alt="Inspiration Gallery">
+</div>
+<div id="gallery-nav">
+<button class="gallery-arrow" id="gallery-prev">&#8249;</button>
+<span id="gallery-counter"></span>
+<button class="gallery-arrow" id="gallery-next">&#8250;</button>
+</div>
+</div>
 
 <script>
 
@@ -244,6 +345,57 @@ document.querySelectorAll(".drawer-zone").forEach(drawer => {
     roomIndex[room] = (idx + 1) % imgs.length;
   });
 });
+
+/* GALLERY */
+
+const galleryImages = [
+  "Assets/gallerydoors.jpg",
+  "Assets/galleryentrance2.jpg",
+  "Assets/galleryentrance3.jpg",
+  "Assets/inspo_gallery1.jpg",
+  "Assets/inspo_gallery2.jpg",
+  "Assets/inspo_gallery3.jpg",
+  "Assets/inspo_gallery4.jpg"
+];
+
+let galleryIdx = 0;
+const galleryOverlay = document.getElementById("gallery-overlay");
+const galleryImg     = document.getElementById("gallery-img");
+const galleryCounter = document.getElementById("gallery-counter");
+
+function updateGallery() {
+  galleryImg.src = galleryImages[galleryIdx];
+  galleryCounter.textContent = (galleryIdx + 1) + " / " + galleryImages.length;
+}
+
+galleryTab.onclick = () => {
+  galleryIdx = 0;
+  updateGallery();
+  galleryOverlay.classList.add("open");
+};
+
+document.getElementById("gallery-close").onclick = () => {
+  galleryOverlay.classList.remove("open");
+};
+
+galleryOverlay.onclick = (e) => {
+  if (e.target === galleryOverlay) galleryOverlay.classList.remove("open");
+};
+
+document.getElementById("gallery-next").onclick = () => {
+  galleryIdx = (galleryIdx + 1) % galleryImages.length;
+  updateGallery();
+};
+
+document.getElementById("gallery-prev").onclick = () => {
+  galleryIdx = (galleryIdx - 1 + galleryImages.length) % galleryImages.length;
+  updateGallery();
+};
+
+galleryImg.onclick = () => {
+  galleryIdx = (galleryIdx + 1) % galleryImages.length;
+  updateGallery();
+};
 
 </script>
 

--- a/index.html
+++ b/index.html
@@ -204,29 +204,44 @@ roomsTab.onclick = () => {
   cabinet.classList.toggle("show");
 };
 
+/* ROOM IMAGE SETS — each drawer cycles through its options on click */
+
+const roomImages = {
+  living: [
+    "Assets/ROOMS_livingroom1.jpg",
+    "Assets/ROOMS_livingroom2.jpg",
+    "Assets/ROOMS_livingroom3.jpg",
+    "Assets/ROOMS_livingroom5.jpg"
+  ],
+  bedroom: [
+    "Assets/ROOMS_bedroom1.jpg",
+    "Assets/ROOMS_bedroom2.jpg",
+    "Assets/ROOMS_bedroom3.jpg"
+  ],
+  dining: [
+    "Assets/ROOMS_diningroom1.jpg",
+    "Assets/ROOMS_diningroom2.jpg"
+  ],
+  spare: [
+    "Assets/ROOMS_bathroom1.jpg",
+    "Assets/ROOMS_kitchen1.jpg",
+    "Assets/ROOMS_office1.jpg"
+  ]
+};
+
+const roomIndex = { living: 0, bedroom: 0, dining: 0, spare: 0 };
+
 /* DRAWER CLICK */
 
 document.querySelectorAll(".drawer-zone").forEach(drawer => {
   drawer.addEventListener("click", () => {
-
     const room = drawer.dataset.room;
+    if (!room || !roomImages[room]) return;
 
-    if (room === "living") {
-      workArea.style.backgroundImage = "url('Assets/room_living.png')";
-    }
-
-    if (room === "bedroom") {
-      workArea.style.backgroundImage = "url('Assets/room_bedroom.png')";
-    }
-
-    if (room === "dining") {
-      workArea.style.backgroundImage = "url('Assets/room_dining.png')";
-    }
-
-    if (room === "spare") {
-      workArea.style.backgroundImage = "url('Assets/room_spare.png')";
-    }
-
+    const imgs = roomImages[room];
+    const idx  = roomIndex[room];
+    workArea.style.backgroundImage = "url('" + imgs[idx] + "')";
+    roomIndex[room] = (idx + 1) % imgs.length;
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the ROOMS drawer system so each drawer cycles through **all available room images** on click, and adds `AGENTS.md` for Cursor Cloud.

## Changes

### `index.html` — Room cycling
Each cabinet drawer now cycles through every matching asset image on repeated clicks:

| Drawer | Rooms | Images |
|---|---|---|
| **Living Room** | 4 | `ROOMS_livingroom1.jpg` → `2` → `3` → `5` |
| **Bedroom** | 3 | `ROOMS_bedroom1.jpg` → `2` → `3` |
| **Dining Room** | 2 | `ROOMS_diningroom1.jpg` → `2` |
| **Spare Rooms** | 3 | `ROOMS_bathroom1.jpg` → `ROOMS_kitchen1.jpg` → `ROOMS_office1.jpg` |

**Total: 12 rooms** (up from 4 broken image references)

Previously each drawer pointed to a single non-existent file (e.g. `room_living.png`). Now the JS uses the actual `ROOMS_*.jpg` assets and cycles through them.

### `AGENTS.md`
Added Cursor Cloud specific instructions for future agents (dev server, key files, notes).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db2268a9-20de-4c88-a223-b668b72f72d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db2268a9-20de-4c88-a223-b668b72f72d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

