### PR TITLE
Stabilize website interactions and fix broken stylesheet block

### DIFF
--- a/index.html
+++ b/index.html
@@ -2315,9 +2315,6 @@ body {
         },
         tables: {
           sections: [
-
-        tables: {
-          sections: [
             {
               title: "COFFEE TABLES",
               assets: [
@@ -2674,8 +2671,6 @@ body {
         return Math.min(max, Math.max(min, value));
       }
 
-      function applyPlacedItemTransform(piece) {
-        const scale = Number(piece.dataset.scale || "1");
       function applyPlacedItemTransform(piece) {
         const scale = Number(piece.dataset.scale || "1");
         const rotation = Number(piece.dataset.rotation || "0");
@@ -3051,10 +3046,6 @@ body {
             state.tilt += 5;
           });
         } else if (action === "rotate-left") {
-          updateSelectedPlacedItem((state) => {
-            state.rotation -= 5;
-          });
-        } else if (action === "rotate-right") {
           updateSelectedPlacedItem((state) => {
             state.rotation -= 5;
           });

--- a/index.html
+++ b/index.html
@@ -1038,8 +1038,6 @@ body {
 
 #work-area::before {
   content: "";
-#work-area::before {
-  content: "";
   position: absolute;
   inset: 0;
   pointer-events: none;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stabilize `index.html` by removing duplicated JS blocks that caused interaction glitches
- fix malformed CSS around `#work-area::before` that disrupted later UI rules
- fix catalog control bar rendering glitch (controls now render as compact vertical buttons, not stretched lines)
- center tab labels inside top pull tabs for consistent alignment
- route the **GALLERY** tab to a dedicated page (`gallery.html`) for immersive viewing
- set the gallery opening sequence to exactly:
  1. `Assets/gallerydoors.jpg`
  2. `Assets/galleryentrance1.jpg`
  3. `Assets/galleryentrance2.jpg`
- add `PREV VIEW` / `NEXT VIEW` scene stepping and keep `BACK TO MAIN`
- make those scenes render as full-screen backgrounds (`object-fit: cover`)
- add robust scene-image fallback loading so gallery still shows images if a referenced filename is missing
- fix gallery error-page behavior by keeping scene transitions in-page (history/query updates + rerender) instead of hard URL navigation
- add `GALLERY_HANDOFF.md` with consolidated gallery HTML/CSS/JS reference blocks

## Validation
- `node --check` passes for extracted inline script
- stylesheet braces are balanced
- Selenium UI checks pass for room switching, catalog preview/place flow, save/checkout receipt, decor switch/back, gallery next view
- additional Selenium geometry check confirms top-tab text centered and catalog controls button sizing restored
- dedicated gallery-page navigation validation confirms:
  - clicking `GALLERY` routes to `/gallery.html`
  - first scene is `gallerydoors.jpg` with title/count shown (`1 / 3`)
  - prev/next updates scene and keeps experience in-page
  - `BACK TO MAIN` returns to `/index.html`
- full-background validation confirms:
  - hero dimensions match stage dimensions
  - `object-fit` is `cover`
- fallback validation confirms every scene resolves to a visible image even when an expected file is absent

## Artifacts
- screenshots and JSON test output saved under `/opt/cursor/artifacts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f663b39a-d567-4e50-aad0-7b1265f76b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f663b39a-d567-4e50-aad0-7b1265f76b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

